### PR TITLE
Comment out centos image in download_boxes.sh

### DIFF
--- a/src/init/download_boxes.sh
+++ b/src/init/download_boxes.sh
@@ -3,8 +3,8 @@
 UBUNTU_BOX_IMAGE="ubuntu/bionic64"
 UBUNTU_BOX_VERSION="20190801.1.0"
 
-CENTOS_BOX_IMAGE="centos/7"
-CENTOS_BOX_VERSION="1905.1"
+#CENTOS_BOX_IMAGE="centos/7"
+#CENTOS_BOX_VERSION="1905.1"
 
 KUBERNETES_BOX_IMAGE="hlesey/k8s-base"
 KUBERNETES_BOX_VERSION="1.15.1"
@@ -13,7 +13,7 @@ KUBERNETES_BOX_VERSION="1.15.1"
 vagrant box add $UBUNTU_BOX_IMAGE --box-version $UBUNTU_BOX_VERSION --provider virtualbox
 
 # add centos
-vagrant box add $CENTOS_BOX_IMAGE --box-version $CENTOS_BOX_VERSION --provider virtualbox
+#vagrant box add $CENTOS_BOX_IMAGE --box-version $CENTOS_BOX_VERSION --provider virtualbox
 
 # kubernetes
 vagrant box add $KUBERNETES_BOX_IMAGE --box-version $KUBERNETES_BOX_VERSION --provider virtualbox


### PR DESCRIPTION
Since we switched docker host to ubuntu bionic we don't need anymore centos image configured in vagrant.
Without this image we will improve the lab prerequisites setup time.