### PR TITLE
Revert "Update ingress fqdns"

### DIFF
--- a/src/deployment-strategies/blue-green/api-ingress.yaml
+++ b/src/deployment-strategies/blue-green/api-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: phippy-api
 spec:
   rules:
-  - host: phippy-api.clusterX.qedzone.ro
+  - host: phippy-api.local
     http:
       paths:
       - path: /

--- a/src/deployment-strategies/canary/api-ingress-canary.yaml
+++ b/src/deployment-strategies/canary/api-ingress-canary.yaml
@@ -9,7 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/canary-weight: "10"
 spec:
   rules:
-  - host: phippy-api.clusterX.qedzone.ro
+  - host: phippy-api.local
     http:
       paths:
       - path: /

--- a/src/deployment-strategies/canary/api-ingress-v1.yaml
+++ b/src/deployment-strategies/canary/api-ingress-v1.yaml
@@ -5,7 +5,7 @@ metadata:
   name: phippy-api
 spec:
   rules:
-  - host: phippy-api.clusterX.qedzone.ro
+  - host: phippy-api.local
     http:
       paths:
       - path: /

--- a/src/deployment-strategies/canary/api-ingress-v2.yaml
+++ b/src/deployment-strategies/canary/api-ingress-v2.yaml
@@ -5,7 +5,7 @@ metadata:
   name: phippy-api
 spec:
   rules:
-  - host: phippy-api.clusterX.qedzone.ro
+  - host: phippy-api.local
     http:
       paths:
       - path: /

--- a/src/helm/wordpress/values.yaml
+++ b/src/helm/wordpress/values.yaml
@@ -6,4 +6,4 @@ service:
 
 ingress:
   enabled: true
-  hostname: wordpress.clusterX.qedzone.ro
+  hostname: wordpress.local

--- a/src/networking/demo/phippy-admin/phippy-admin.yaml
+++ b/src/networking/demo/phippy-admin/phippy-admin.yaml
@@ -56,7 +56,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-   - host: phippy-admin.clusterX.qedzone.ro
+   - host: phippy-admin.local
      http:
       paths:
       - path: /

--- a/src/networking/demo/phippy-user/phippy-user.yaml
+++ b/src/networking/demo/phippy-user/phippy-user.yaml
@@ -56,7 +56,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-   - host: phippy-user.clusterX.qedzone.ro
+   - host: phippy-user.local
      http:
       paths:
       - path: /

--- a/src/observability/prometheus/deployment.yaml
+++ b/src/observability/prometheus/deployment.yaml
@@ -90,7 +90,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-   - host: prometheus.clusterX.qedzone.ro
+   - host: prometheus.local
      http:
       paths:
       - path: /

--- a/src/services/my-ingress.yaml
+++ b/src/services/my-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-   - host: myapp.clusterX.qedzone.ro
+   - host: myapp.local
      http:
       paths:
       - path: /foo


### PR DESCRIPTION
Reverts hlesey/k8s-labs#13

Need lower case `x` in `clusterX, otherwise it will crash with
```
spec.rules[0].host: Invalid value: "clusterX.qedzone.ro": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
```